### PR TITLE
fix(config): cast redis port into int

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -187,7 +187,7 @@ $db = [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
-            'port' => env('REDIS_PORT', 6379),
+            'port' => (int) env('REDIS_PORT', 6379),
             'database' => env('REDIS_DB', env('REDIS_DATABASE', 0)),
         ],
 
@@ -195,7 +195,7 @@ $db = [
             'url' => env('REDIS_URL'),
             'host' => env('REDIS_HOST', '127.0.0.1'),
             'password' => env('REDIS_PASSWORD', null),
-            'port' => env('REDIS_PORT', 6379),
+            'port' => (int) env('REDIS_PORT', 6379),
             'database' => env('REDIS_CACHE_DB', 1),
         ],
 


### PR DESCRIPTION
Hi there,

I tried to use Redis as a cache / queue manager and I am facing this error:
`Redis::connect(): Argument #2 ($port) must be of type int, string given`

Seems like it can be easily fixed by casting value into an int value. see:
https://github.com/laravel/framework/issues/36693
